### PR TITLE
License cleanup patch

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -58,7 +58,7 @@ _NO ASSOCIATION._
 Copyright (c) 2017-2022, Python Test Repo Template
 ALSO Licensed under MIT
 You may obtain a copy of the License at
-[MIT License](https://github.com/reactive-firewall/python-repo/LICENSE.md)
+[MIT License](https://github.com/reactive-firewall/python-repo/blob/HEAD/LICENSE.md)
 ***
 
 ### Files: `.github/workflows/markdown-lint.yml`, and `.github/workflows/yaml-lint.yml`
@@ -67,7 +67,7 @@ You may obtain a copy of the License at
 Copyright (c) 2017-2025, Your Mileage May Vary
 ALSO Licensed under MIT
 You may obtain a copy of the License at
-[MIT License](https://github.com/reactive-firewall/ymmv/LICENSE.md)
+[MIT License](https://github.com/reactive-firewall/ymmv/blob/HEAD/LICENSE.md)
 ***
 
 ### File: `Logo.svg`

--- a/tests/profiling.py
+++ b/tests/profiling.py
@@ -9,7 +9,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 # ..........................................
-# https://github.com/reactive-firewall/python-repo/LICENSE.md
+# https://github.com/reactive-firewall/python-repo/blob/HEAD/LICENSE.md
 # ..........................................
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -9,7 +9,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 # ..........................................
-# https://github.com/reactive-firewall/python-repo/LICENSE.md
+# https://github.com/reactive-firewall/python-repo/blob/HEAD/LICENSE.md
 # ..........................................
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -9,7 +9,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 # ..........................................
-# https://github.com/reactive-firewall/python-repo/LICENSE.md
+# https://github.com/reactive-firewall/python-repo/blob/HEAD/LICENSE.md
 # ..........................................
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -9,7 +9,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 # ..........................................
-# https://github.com/reactive-firewall/python-repo/LICENSE.md
+# https://github.com/reactive-firewall/python-repo/blob/HEAD/LICENSE.md
 # ..........................................
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
# Patch Notes

Updated a few more License URLs to direct links.

## Impacted GHI

 - [x] Closes #335

## Included and Superseded PR/MRs

 * Includes #425
 * Includes #426
 * Includes #427
 * Includes #428
 * Includes #433

## Changes by file in this patch

Changes in file LICENSE.md:
 * updated a few more licences to direct links

Changes in file tests/profiling.py:
 * updated python-repo licences to direct link

Changes in file tests/test_basic.py:
 * updated python-repo licences to direct link

Changes in file tests/test_build.py:
 * updated python-repo licences to direct link

Changes in file tests/test_usage.py:
 * updated python-repo licences to direct link
 
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated license reference URLs in documentation and file headers to point to the latest version on the default branch. No functional changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->