### PR TITLE
[SECURITY] Version Bump for pip to `25.2`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ branding::
 	$(QUIET)$(ECHO) ""
 
 init: branding
-	$(QUIET)$(PYTHON) -m pip $(PIP_PREFIX_FLAGS) install $(PIP_COMMON_FLAGS) $(PIP_ENV_FLAGS) "pip>=25.1.1" "setuptools>=80.9" "wheel>=0.45" "build>=1.2.1" || DO_FAIL="exit 69" ;  # 69: [pip] Service unavailable - does not exist.
+	$(QUIET)$(PYTHON) -m pip $(PIP_PREFIX_FLAGS) install $(PIP_COMMON_FLAGS) $(PIP_ENV_FLAGS) "pip>=25.2" "setuptools>=80.9" "wheel>=0.45" "build>=1.2.1" || DO_FAIL="exit 69" ;  # 69: [pip] Service unavailable - does not exist.
 	$(QUIET)$(DO_FAIL) 2>$(ERROR_LOG_PATH) >>/dev/null ;
 	$(QUIET)$(PYTHON) -m pip $(PIP_PREFIX_FLAGS) install $(PIP_COMMON_FLAGS) $(PIP_ENV_FLAGS) -r requirements.txt 2>$(ERROR_LOG_PATH) || DO_FAIL="exit 69" ;  # 69: [pip] Service unavailable - does not exist.
 	$(QUIET)$(DO_FAIL) 2>$(ERROR_LOG_PATH) >>/dev/null ;

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -37,7 +37,7 @@ setuptools>=80.9
 # wheel - MIT license
 wheel>=0.45
 # pip - MIT license
-pip>=25.1.1
+pip>=25.2
 # build - MIT license
 build>=1.2.1, !=1.2.2.post1
 # sphinx - BSD license

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ setuptools>=80.9
 # virtualenv - MIT license
 # virtualenv>=20.26.6
 # pip - MIT license
-pip>=25.1.1
+pip>=25.2
 # build - MIT license
 build>=1.2.1, !=1.2.2.post1
 # multicast - MIT license (MITNFA)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -93,6 +93,6 @@ coverage>=7.2
 # wheel - MIT license
 wheel>=0.45
 # pip - MIT license
-pip>=25.1.1
+pip>=25.2
 # build - MIT license
 build>=1.2.1, !=1.2.2.post1


### PR DESCRIPTION
# Patch Notes

* Resolves [GHSA-4xh5-x5gv-qwph](https://osv.dev/vulnerability/GHSA-4xh5-x5gv-qwph)

## Impacted GHI

 - [x] Closes #477

## Changes

Changes in file Makefile:
 * version bump for pip

Changes in file docs/requirements.txt:
 * version bump for pip

Changes in file requirements.txt:
 * version bump for pip

Changes in file tests/requirements.txt:
 * version bump for pip